### PR TITLE
Fix String.format pattern in toSOQL()

### DIFF
--- a/sfdx-source/apex-common/main/classes/criteria/fflib_Criteria.cls
+++ b/sfdx-source/apex-common/main/classes/criteria/fflib_Criteria.cls
@@ -594,7 +594,7 @@ public virtual with sharing class fflib_Criteria
 		public String toSOQL()
 		{
 			return String.format(
-					'{0} {2} {3}',
+					'{0} {1} {2}',
 					new List<String>
 					{
 							this.sObjectField.getDescribe().getName(),


### PR DESCRIPTION
There was a typo in pattern `{0} {2} {3}` -> `{0} {1} {2}`